### PR TITLE
add license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hpkp",
   "author": "Adam Baldwin <baldwin@andyet.net> (http://andyet.net/team/baldwin)",
+  "license": "MIT",
   "contributors": [
     "Evan Hahn <me@evanhahn.com> (http://evanhahn.com)"
   ],


### PR DESCRIPTION
It's very useful for us to have the package "stamped" with the license info so our automated tools can know whether it's OK to use this in our corp environment.